### PR TITLE
[DM/InfolisFile] Fix typo in owl:sameAs property

### DIFF
--- a/data/infolis.tson
+++ b/data/infolis.tson
@@ -426,7 +426,7 @@ InfolisPattern
 InfolisFile
 	@context
 		dc:description "A resource representing a file on the server."
-		owl:sameAs.
+		owl:sameAs
 			@id omnom:File
 	md5
 		@context


### PR DESCRIPTION
There are more errors or warnings about our data model:

http://graphite.ecs.soton.ac.uk/checker/?uri=http://infolis.gesis.org/infolink/schema

Can someone look at those as well and fix them?
